### PR TITLE
Direct calc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,3 +134,7 @@ add_executable( QuartetScores "src/QuartetScores.cpp" )
 target_link_libraries ( QuartetScores ${GENESIS_LINK_LIBRARIES} )
 target_link_libraries(QuartetScores ${STXXL_LIBRARIES})
 target_link_libraries(QuartetScores easyloggingpp)
+
+add_executable(test_em_counting tests/em_counting.cpp)
+target_link_libraries(test_em_counting ${STXXL_LIBRARIES})
+add_test(test_em_counting test_em_counting)

--- a/src/QuartetCounterLookup.hpp
+++ b/src/QuartetCounterLookup.hpp
@@ -287,7 +287,6 @@ void QuartetCounterLookup<CINT>::countQuartets(const std::string &evalTreesPath,
 			}
 
 			if (quartetSorter.size() > max_em_elements) {
-				std::cout << "Reduce sorter" << std::endl;
 				quartetSorter.sort();
 				quartetCount.update(quartetSorter);
 				quartetSorter.clear();

--- a/src/QuartetScoreComputer.hpp
+++ b/src/QuartetScoreComputer.hpp
@@ -42,13 +42,15 @@ class QuartetScoreComputer {
 public:
 	QuartetScoreComputer(Tree const &refTree, const std::string &evalTreesPath, size_t m, bool verboseOutput,
 			bool enforceSmallMem, int num_threads, int internalMemory, std::vector<size_t>& refIdToLookupID);
+
 	using QuartetTuple = std::array<uint16_t, 4>;
 	using QuartetCountTuple = std::array<CINT, 3>;
+
 	std::vector<double> getLQICScores();
 	std::vector<double> getQPICScores();
 	std::vector<double> getEQPICScores();
 	void calculateQPICScores();
-	void computeQuartetScoresBifurcatingQuartets(size_t uIdx, size_t vIdx, size_t wIdx, size_t zIdx, std::vector<CINT> quartetOccurrences);
+	void computeQuartetScoresBifurcatingQuartets(size_t uIdx, size_t vIdx, size_t wIdx, size_t zIdx, QuartetCountTuple quartetOccurrences);
 	void init(size_t num_taxa);
 	size_t num_taxa() const;
 	std::vector<uint16_t> get_leaves(uint64_t q);
@@ -405,7 +407,7 @@ std::tuple<size_t, size_t, size_t, size_t> QuartetScoreComputer<CINT>::getRefere
  * Compute the LQ-IC, QP-IC, and EQP-IC scores for a bifurcating reference tree, iterating over quartets instead of node pairs.
  */
 template<typename CINT>
-void QuartetScoreComputer<CINT>::computeQuartetScoresBifurcatingQuartets(size_t uIdx, size_t vIdx, size_t wIdx, size_t zIdx, std::vector<CINT> quartetOccurrences) {
+void QuartetScoreComputer<CINT>::computeQuartetScoresBifurcatingQuartets(size_t uIdx, size_t vIdx, size_t wIdx, size_t zIdx, QuartetCountTuple quartetOccurrences) {
 	// Process all quartets
 	//#pragma omp parallel for schedule(dynamic)
 					// find topology ab|cd of {u,v,w,z}
@@ -500,8 +502,9 @@ void QuartetScoreComputer<CINT>::computeQuartetScoresBifurcatingQuartets(size_t 
 							referenceTree.node_at(lcaFromToIdx))) {
 						if (it.is_lca())
 							continue;
+
+						size_t edge = it.edge().index();
 #pragma omp critical
-						size_t egde = it.edge().index();
 						LQICScores[edge] = std::min(LQICScores[it.edge().index()], qic);
 					}
 					std::get<0>(countBuffer[nodePairSorted]) += quartetOccurrences[tupleA];

--- a/src/em_counting.hpp
+++ b/src/em_counting.hpp
@@ -33,15 +33,20 @@ public:
     // before using it again
     template<typename Stream>
     void update(Stream& in) {
+        _stream.reset(nullptr);
+
         if (in.empty())
             return;
 
-        auto count_next = [&in] () -> value_type {
+        size_t in_count = 0;
+        auto count_next = [&in, &in_count] () -> value_type {
             if (in.empty()) return {Key{}, 0};
 
             auto current = *in;
             count_type count = 1;
             for(++in; !in.empty() && *in == current; ++count, ++in);
+
+            in_count += count;
 
             return {current, count};
         };
@@ -57,6 +62,8 @@ public:
         // first run:  _sequence is empty and we do not have to merge
         if (_sequence.empty()) {
             in_to_stream(_sequence);
+            std::cout << "Reduced sorter with " << in_count << " keys. "
+                         "Sequence contains " << _sequence.size() << " pairs.\n";
             return;
         }
 
@@ -91,7 +98,9 @@ public:
         // copy remainder from in
         in_to_stream(result);
 
-        _stream.reset(nullptr);
+        std::cout << "Reduced sorter with " << in_count << " keys. "
+                     "Sequence contains " << result.size() << " pairs "
+                     "(previously " << _sequence.size() << ")\n";
         _sequence.swap(result);
     }
 

--- a/src/em_counting.hpp
+++ b/src/em_counting.hpp
@@ -1,0 +1,129 @@
+#ifndef HEADER_EM_COUNTING_HPP
+#define HEADER_EM_COUNTING_HPP
+
+#include <stxxl/sequence>
+#include <cassert>
+#include <memory>
+#include <utility>
+
+template <typename Key, typename Count>
+class em_counting {
+public:
+    using key_type = Key;
+    using count_type = Count;
+    using value_type = std::pair<key_type, count_type>;
+
+private:
+    using sequence_type = stxxl::sequence<value_type>;
+    using stream_type = typename sequence_type::stream;
+    using pool_type = stxxl::read_write_pool<typename sequence_type::block_type>;
+
+public:
+
+    em_counting()
+        : _pool(2 * stxxl::config::get_instance()->disks_number(),
+                2 * stxxl::config::get_instance()->disks_number() + 4),
+          _sequence(_pool)
+    {}
+
+    em_counting(const em_counting&) = delete;
+    em_counting& operator=(const em_counting&) = delete;
+
+    // Updates counts and invalidates streaming interface. Call rewind
+    // before using it again
+    template<typename Stream>
+    void update(Stream& in) {
+        if (in.empty())
+            return;
+
+        auto count_next = [&in] () -> value_type {
+            if (in.empty()) return {Key{}, 0};
+
+            auto current = *in;
+            count_type count = 1;
+            for(++in; !in.empty() && *in == current; ++count, ++in);
+
+            return {current, count};
+        };
+
+        auto in_to_stream = [&in, count_next] (sequence_type& result) {
+            while(true) {
+                auto count = count_next();
+                if (!count.second) break;
+                result.push_back(count);
+            }
+        };
+
+        // first run:  _sequence is empty and we do not have to merge
+        if (_sequence.empty()) {
+            in_to_stream(_sequence);
+            return;
+        }
+
+        // both input sources contain data, so we have to merge
+        sequence_type result(_pool);
+        {
+            auto sstream = _sequence.get_stream();
+
+            while (!(sstream.empty() || in.empty())) {
+                auto count = count_next();
+                if (!count.second) break;
+
+                // copy elements from sequence that are not contained in in
+                for (; !sstream.empty() &&
+                       (*sstream).first < count.first; ++sstream)
+                    result.push_back(*sstream);
+
+                // if current element is already in sequence, we add counts
+                if (!sstream.empty() && (*sstream).first == count.first) {
+                    count.second += (*sstream).second;
+                    ++sstream;
+                }
+
+                result.push_back(count);
+            }
+
+            // copy remainder from _sequence
+            for (; !sstream.empty(); ++sstream)
+                result.push_back(*sstream);
+        }
+
+        // copy remainder from in
+        in_to_stream(result);
+
+        _stream.reset(nullptr);
+        _sequence.swap(result);
+    }
+
+// stream
+    // todo: we could implement the stream s.t. the last update is unnecessary
+
+    void rewind() {
+        _stream.reset(nullptr); // free blocks
+        _stream.reset(new stream_type(_sequence));
+    }
+
+    const value_type& operator*() const {
+        assert(_stream);
+        return **_stream;
+    }
+
+    bool empty() const {
+        assert(_stream);
+        return _stream->empty();
+    }
+
+    em_counting& operator++() {
+        assert(_stream);
+        ++(*_stream);
+    }
+
+
+private:
+    pool_type _pool;
+    sequence_type _sequence;
+    std::unique_ptr<stream_type> _stream;
+
+};
+
+#endif // HEADER_EM_COUNTING_HPP

--- a/tests/em_counting.cpp
+++ b/tests/em_counting.cpp
@@ -1,0 +1,109 @@
+#include "../src/em_counting.hpp"
+
+#include <stxxl/bits/stream/stream.h>
+
+#include <iostream>
+#include <random>
+#include <vector>
+
+using T = uint32_t;
+std::mt19937_64 prng;
+
+void ensure(bool cond) {
+    if (!cond) {
+        std::cerr << "Fail\n";
+        abort();
+    }
+}
+
+
+std::vector<T> generate_random_vector(size_t n, T max_value) {
+    std::uniform_int_distribution<T> dist(0, max_value);
+
+    std::vector<T> result;
+    result.reserve(n);
+
+    for(size_t i=0; i<n; i++)
+        result.push_back(dist(prng));
+
+    return result;
+}
+
+template <typename It>
+std::vector< std::pair<T, size_t> > distribution(It begin, It end) {
+    std::sort(begin, end);
+    std::vector< std::pair<T, size_t> > distr;
+
+    size_t count = 1;
+    T last = *begin;
+    for(auto i = begin + 1; i != end; i++) {
+        if (last != *i) {
+            distr.emplace_back(last, count);
+            last = *i;
+            count = 0;
+        }
+
+        count++;
+    }
+
+    distr.emplace_back(last, count);
+
+    return distr;
+}
+
+void check_counting(size_t n, T max_value) {
+    auto vec = generate_random_vector(n, max_value);
+    std::uniform_int_distribution<size_t> dist(1, n / 10);
+
+    size_t i = 0;
+
+    em_counting<T, size_t> counter;
+
+    while(i < n) {
+        const size_t chunk = std::min<size_t>(dist(prng), n - i);
+
+        auto begin = vec.begin() + i;
+        auto end = begin + chunk;
+
+        std::cout << i << ":" << chunk << "\n";
+
+        {
+            std::sort(begin, end);
+            auto str = stxxl::stream::streamify(begin, end);
+            counter.update(str);
+        }
+
+        i += chunk;
+    }
+
+    auto distr = distribution(vec.begin(), vec.end());
+
+    for(int it = 0; it < 2; it++) {
+        counter.rewind();
+
+        for(auto ref : distr) {
+            ensure(!counter.empty());
+
+            auto& citem = *counter;
+
+            ensure(citem.first == ref.first);
+            ensure(citem.second == ref.second);
+
+            ++counter;
+        }
+
+        ensure(counter.empty());
+    }
+}
+
+int main() {
+    for(int i=0; i<10; i++) {
+        check_counting(10000, 10); // dense
+        check_counting(10000, 1000);
+        check_counting(10000, 100000);
+    }
+
+    std::cout << "Ok\n";
+
+    return 0;
+}


### PR DESCRIPTION
Adds the em_counting module (and a unit test). This module maintains a sequence with counts observed so far. It has a method update expecting a sorted stream of elements. These are counted and merged into the current sequence.

`QuartetCounterLookup::countQuartets` now gets an optional argument `max_em_elements` defaulting to 1<<34 (i.e. 256 GiB). After each evalutation tree, it checks whether the elements in the sorter exceed this number and in this case, reduces the sorter into the em_counting module.

I'm quite sure that the `em_counting` module works fine as the unit test does not indicate issues. I do not know how to check the QuartetScore results; thus I cannot vouch for my modifications there. All I can tell you is that it does not crash. Please have a look at the code and check the results!